### PR TITLE
fix backup success check for mongodb 3.6

### DIFF
--- a/backup-mongodb.sh
+++ b/backup-mongodb.sh
@@ -68,7 +68,7 @@ create_backup() {
 		docker exec $container mongo admin --eval "db.runCommand({createBackup: 1, backupDir: '$backup_dir'})" > $out
 	fi
 
-	if ! grep -q '{ "ok" : 1 }' $out; then
+	if ! grep -q '"ok" : 1' $out; then
 		cat >&2 "$out"
 		rm "$out"
 		return 1


### PR DESCRIPTION
Since from mongodb 3.6 backup script failed:
```
# ./backup-mongodb.sh mongodb /backup user password
Percona Server for MongoDB shell version v3.6.8-2.0
connecting to: mongodb://127.0.0.1:27017/admin
Percona Server for MongoDB server version: v3.6.8-2.0
{
        "ok" : 1,
        "operationTime" : Timestamp(000000000, 2),
        "$clusterTime" : {
                "clusterTime" : Timestamp(000000000, 2),
                "signature" : {
                        "hash" : BinData(0,"xxxxxxxx"),
                        "keyId" : NumberLong("xxxxxxxxx")
                }
        }
}
Failed to create backup
```
This PR modifies script to grep correct success string.